### PR TITLE
Remove assert checking

### DIFF
--- a/conf_linux_public.py
+++ b/conf_linux_public.py
@@ -235,9 +235,9 @@ if args.get('compiler') == "clang":
 #Default parameters (default flow):
 else:
     cmake_command.append(
-        '-DCMAKE_C_FLAGS_RELEASE="-O2 -Wformat -Wformat-security -Wall -Werror -D_FORTIFY_SOURCE=2 -DNDEBUG -fstack-protector-strong"')
+        '-DCMAKE_C_FLAGS_RELEASE="-O2 -Wformat -Wformat-security -Wall -Werror -D_FORTIFY_SOURCE=2 -fstack-protector-strong"')
     cmake_command.append(
-        '-DCMAKE_CXX_FLAGS_RELEASE="-O2 -Wformat -Wformat-security -Wall -Werror -D_FORTIFY_SOURCE=2 -DNDEBUG -fstack-protector-strong"')
+        '-DCMAKE_CXX_FLAGS_RELEASE="-O2 -Wformat -Wformat-security -Wall -Werror -D_FORTIFY_SOURCE=2 -fstack-protector-strong"')
 
 cmake_command.append('-DBUILD_TESTS=ON ')
 


### PR DESCRIPTION
Since support for switching to release branches was added, flag -DNDEBUG is not needed in master